### PR TITLE
Experimental/test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN npm install -g \
     express-generator \
     rollup
 
-RUN npm -g --unsafe-perm install node-sass
+RUN npm -g --unsafe-perm install http-server
 
 # ability to run puppeteer inside a Docker container
 # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
@@ -38,7 +38,7 @@ RUN mkdir /www
 RUN chmod 777 /www
 
 # Expose port
-EXPOSE 5000
+EXPOSE 3000
 
 # Run with bash
 WORKDIR /www

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,11 @@ RUN apt-get update && apt-get -y install \
     vim \
     curl \
     bash \
-    nano \
-    tree \
-    git \
-    libfontconfig
+    git
 
 USER root
 
-RUN npm install -g http-server
+RUN npm i -g http-server
 
 # ability to run puppeteer inside a Docker container
 # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
@@ -33,9 +30,9 @@ RUN chmod +x /usr/local/bin/dumb-init
 RUN mkdir /www
 RUN chmod 777 /www
 
-# Expose port
-EXPOSE 3000
-
 # Run with bash
 WORKDIR /www
 CMD ["/bin/bash"]
+
+# Expose port
+EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:latest
 
 RUN apt-get update && apt-get -y install \
+    vim \
     curl \
     bash \
     nano \
@@ -10,12 +11,7 @@ RUN apt-get update && apt-get -y install \
 
 USER root
 
-RUN npm install -g \
-    gulp \
-    express-generator \
-    rollup
-
-RUN npm -g --unsafe-perm install http-server
+RUN npm install -g http-server
 
 # ability to run puppeteer inside a Docker container
 # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker

--- a/README.md
+++ b/README.md
@@ -6,20 +6,30 @@
 
 > Prerequisites: [docker](https://store.docker.com/editions/community/docker-ce-desktop-mac)
 
-**1. Build the docker image and container:**
-  `. build.sh`
+1. Build the docker image and container:
+```sh
+. build.sh
+```
 
-**2. Start the container and attach to it:**
-  `docker start puppeteer-mocha-poc && docker attach puppeteer-mocha-poc`
+2. Start the container and attach to it:
+```sh
+docker start puppeteer-mocha-poc && docker attach puppeteer-mocha-poc
+```
  
-**3. Install dependencies**
-  `npm install` or just `npm i`
+3. Install dependencies
+```sh
+npm install
+```
 
-**4. Start the server**
-  `npm run forever`
+4. Start the server
+```sh
+npm run forever
+```
 
-**3. Run the test script:**
-  `npm run test` or just `npm test`
+5. Run the test script:
+```sh
+npm run test
+```
 
 ## Acceptance Criteria
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,34 @@
 
 > The goal of this POC is to be able to test .js on a webpage using Mocha and Puppeteer.
 
+## Instructions to Reproduce the POC 
+
+> Prerequisites: [docker](https://store.docker.com/editions/community/docker-ce-desktop-mac)
+
+**1. Build the docker image and container:**
+  `. build.sh`
+
+**2. Start the container and attach to it:**
+  `docker start puppeteer-mocha-poc && docker attach puppeteer-mocha-poc`
+ 
+**3. Install dependencies**
+  `npm install` or just `npm i`
+
+**4. Start the server**
+  `npm run forever`
+
+**3. Run the test script:**
+  `npm run test` or just `npm test`
+
 ## Acceptance Criteria
 
-- [ ] Project includes an empty `custom element` in the `src` directory. It needs some dummy logic to make it testable.
-- [ ] Project has an `index.html` file in the `test` directory that references the custom element.
+- [x] Project includes an empty `custom element` in the `src` directory. It needs some dummy logic to make it testable.
+- [x] Project has an `index.html` file in the `test` directory that references the custom element.
 - [ ] Project needs a mocha test spec to run 2-3 tests on the element.
-- [ ] All 3rd party deps need to be managed via `npm`. No copy/pasted libs in `src` or `test`
-- [ ] All setup and teardown of the tests should be able to run via `npm run test`
+- [x] All 3rd party deps need to be managed via `npm`. No copy/pasted libs in `src` or `test`
+- [x] All setup and teardown of the tests should be able to run via `npm run test`
 - [ ] Document all steps to setup and reproduce the POC
-- [ ] Use the Dockerfile (see instructions below)
+- [x] Use the Dockerfile (see instructions below)
 
 ---
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+imageName=web-image
+containerName=puppeteer-mocha-poc
+
+docker build -t $imageName -f Dockerfile  .
+
+echo Delete old container...
+docker rm -f $containerName
+
+echo Run new container...
+docker run -it -d -p 3000:3000 --name $containerName -v $(pwd):/www/ $imageName

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 imageName=web-image
 containerName=puppeteer-mocha-poc
 
-docker build -t $imageName -f Dockerfile  .
+docker build --no-cache -t $imageName -f Dockerfile  .
 
 echo Delete old container...
 docker rm -f $containerName

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,414 @@
+{
+  "name": "tech-poc-puppeteer-mocha",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+    },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "mime": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
+      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg=="
+    },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+    },
+    "puppeteer": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.10.0.tgz",
+      "integrity": "sha512-3i28X/ucX8t3eL4TZA60FLMOQNKqudFSOGDHr0cT7T4dE027CrcS885aAqjdxNybhMPliM5yImNsKJ6SQrPzhw==",
+      "requires": {
+        "debug": "^3.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.0",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^5.1.1"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "^7.0.5"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "requires": {
+        "fd-slicer": "~1.0.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "test": "mocha test/bootstrap.js --recursive test",
-    "server": "http-server -c-1 test",
-    "forever": "http-server . > http.log 2>&1 &"
+    "server": "http-server -c-1 test -p 3000",
+    "forever": "http-server -c-1 -p 3000 . > http.log 2>&1 &"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test": "mocha test/bootstrap.js --recursive test",
-    "server": "http-server -c-1 test"
+    "server": "http-server -c-1 test",
+    "forever": "http-server . > http.log 2>&1 &"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "tech-poc-puppeteer-mocha",
+  "version": "1.0.0",
+  "description": "The goal of this POC is to be able to test .js on a webpage using Mocha and Puppeteer.",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "mocha test/bootstrap.js --recursive test",
+    "server": "http-server -c-1 test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/frog-ny/tech-poc-puppeteer-mocha.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/frog-ny/tech-poc-puppeteer-mocha/issues"
+  },
+  "homepage": "https://github.com/frog-ny/tech-poc-puppeteer-mocha#readme",
+  "dependencies": {
+    "chai": "^4.2.0",
+    "lodash": "^4.17.11",
+    "mocha": "^5.2.0",
+    "puppeteer": "^1.10.0"
+  }
+}

--- a/src/source.js
+++ b/src/source.js
@@ -1,22 +1,69 @@
-class Foo extends HTMLElement {
+const template = document.createElement('template');
 
+
+class Counter extends HTMLElement {
   static get observedAttributes() {
-    return ['data-foo'];
+    return ['data-foo', 'value'];
   }
 
   constructor(){
     super();
+
+    // console.log(this.appendChild);
+
+    this.increment = this.increment.bind(this);
   }
 
   connectedCallback() {
+    this.addEventListener('click', this.increment);
+    if (!this.hasAttribute('value')){
+      this.setAttribute('value', 0);
+    }
+
+    this.innerHTML = `
+      <div class='counter-wrapper'>
+        <button class='counter-button' tabindex='0' increment>Increment</button>
+        <span class='counter-count'></span>
+      </div>
+    `;
+
+    this.incrementBtn = this.querySelector('[increment]');
+    this.displayVal = this.querySelector('span');
+    this.displayVal.innerText = this.value;
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
+    if (this.displayVal !== undefined){
+      this.displayVal.innerText = this.value;
+    }
   }
 
   disconnectedCallback(){
+    this.removeEventListener('click', this.increment);
   }
 
+  increment() {
+    const step = +this.step || 1;
+    const newValue = +this.value + step;
+
+    this.value = +newValue;
+  }
+
+  get value() {
+    return this.getAttribute('value');
+  }
+
+  get step() {
+    return this.getAttribute('step');
+  }
+
+  set value(newValue) {
+    this.setAttribute('value', newValue);
+  }
+
+  set step(newValue) {
+    this.setAttribute('step', newValue);
+  }
 }
 
-customElements.define('exa-foo', Foo);
+customElements.define('exa-counter', Counter);

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,0 +1,23 @@
+const puppeteer = require('puppeteer');
+const { expect } = require('chai');
+const _ = require('lodash');
+const globalVariables = _.pick(global, ['browser', 'expect']);
+
+// puppeteer opts
+const opts = {
+  headless: false,
+  slowMo: 100,
+  timeout: 10000
+};
+
+before (async () => {
+  global.expect = expect;
+  global.browser = await puppeteer.launch(opts);
+});
+
+after (() => {
+  browser.close();
+
+  global.browser = globalVariables.browser;
+  global.expect = globalVariables.expect;
+});

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -5,8 +5,9 @@ const globalVariables = _.pick(global, ['browser', 'expect']);
 
 // puppeteer opts
 const opts = {
-  headless: false,
+  headless: true,
   slowMo: 100,
+  args: ['--no-sandbox'],
   timeout: 10000
 };
 

--- a/test/index.html
+++ b/test/index.html
@@ -12,10 +12,7 @@
     <main>
       <h1>Foo : Test</h1>
 
-      <exa-foo data-foo='Bar'>
-        <h2>This is a Foo component.</h2>
-      </exa-foo>
-
+      <exa-counter data-foo='bar'></exa-counter>
     </main>
 
   </body>

--- a/test/sample.spec.js
+++ b/test/sample.spec.js
@@ -6,7 +6,7 @@ describe('sample test', function() {
   before (async function() {
     this.timeout(5000);
     page = await browser.newPage();
-    await page.goto('http://localhost:3000/test'); # needs to map to the http-server and exposed port
+    await page.goto('http://localhost:3000/test'); // needs to map to the http-server and exposed port
   });
 
   after (async () => {

--- a/test/sample.spec.js
+++ b/test/sample.spec.js
@@ -1,0 +1,23 @@
+const { expect } = require('chai');
+
+describe('sample test', () => {
+  let page;
+
+  before (async () => {
+    page = await browser.newPage();
+    await page.goto('http://localhost:8080/test');
+  });
+
+  after (async () => {
+    await page.close();
+  });
+
+  it('should have one button', async () => {
+    const BUTTON_SELECTOR = '.counter-button';
+    const title = await page.title();
+
+    const button = await page.waitFor(BUTTON_SELECTOR);
+
+    expect(await page.$$(BUTTON_SELECTOR)).to.have.lengthOf(1);
+  });
+});

--- a/test/sample.spec.js
+++ b/test/sample.spec.js
@@ -1,18 +1,20 @@
 const { expect } = require('chai');
 
-describe('sample test', () => {
+describe('sample test', function() {
   let page;
 
-  before (async () => {
+  before (async function() {
+    this.timeout(5000);
     page = await browser.newPage();
-    await page.goto('http://localhost:8080/test');
+    await page.goto('http://localhost:3000/test'); # needs to map to the http-server and exposed port
   });
 
   after (async () => {
     await page.close();
   });
 
-  it('should have one button', async () => {
+  it('should have one button', async function() {
+    this.timeout(5000);
     const BUTTON_SELECTOR = '.counter-button';
     const title = await page.title();
 


### PR DESCRIPTION
Still need to write a few more unit tests, but end-to-end puppeteer+mocha test is working on docker.

Some notes: 
- needed to remap ports so puppeteer was pointing to the http-server and docker was exposing that port 
- needed the `['--no-sandbox']` flag for puppeteer, as well as headless
- needed to change the default timeout for a mocha test; 2000ms was not enough time for the container to fire up puppeteer
- puppeteer needs to built / installed in the docker container, not locally, i.e. `npm install` after you attach to the container